### PR TITLE
RTSP/RTP Streaming integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/Windows-Camera"]
+	path = external/Windows-Camera
+	url = https://github.com/microsoft/Windows-Camera/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,8 @@ find_package(Boost REQUIRED COMPONENTS system thread)
 set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set (CMAKE_CXX_EXTENSIONS FALSE)
-set (CMAKE_CXX_FLAGS "/EHsc")
+
+add_compile_options(/EHsc)
 
 roslint_cpp()
 add_message_files(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(Boost REQUIRED COMPONENTS system thread)
 set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set (CMAKE_CXX_EXTENSIONS FALSE)
+set (CMAKE_CXX_FLAGS "/EHsc")
 
 roslint_cpp()
 add_message_files(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,12 +30,13 @@ include_directories(
   include
   ${catkin_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
-  external/Windows-Camera/Samples/NetworkMediaStreamer/Common/inc
+  external/Windows-Camera/NetworkMediaStreamer/Common/inc
   )
 
-#if(ENABLE_RTSP)
+if(ENABLE_RTSP)
 include(external/CmakeLists.txt)
-#endif(ENABLE_RTSP)
+endif(ENABLE_RTSP)
+
 ## Declare a cpp library
 add_library(win_camera STATIC src/winrospublisher.cpp src/wincapture.cpp)
 
@@ -46,7 +47,11 @@ set_target_properties(msft_camera_nodelet PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 
 
 ## Declare a cpp executable
 add_executable(msft_camera_node src/msftcameranode.cpp)
-add_dependencies(msft_camera_node win_camera RTPMediaStreamer RTSPServer)
+add_dependencies(msft_camera_node win_camera)
+if(ENABLE_RTSP)
+add_dependencies(msft_camera_node RTPMediaStreamer RTSPServer)
+endif(ENABLE_RTSP)
+
 add_dependencies(msft_camera_nodelet win_camera)
 
 ## Specify libraries to link a library or executable target against
@@ -54,30 +59,32 @@ target_link_libraries(win_camera
   ${catkin_LIBRARIES}
   )
 
+if(ENABLE_RTSP)
+set(RTSP_LIBS 
+    RTPMediaStreamer 
+    RTSPServer)
+endif(ENABLE_RTSP)
+
+set (COMMON_LIBS 
+     win_camera
+     mf
+     mfplat
+     mfuuid
+     mfreadwrite
+     Mfsensorgroup
+     shlwapi
+     runtimeobject)
+
 target_link_libraries(msft_camera_nodelet
   ${catkin_LIBRARIES}
-  win_camera
-  mf
-  mfplat
-  mfuuid
-  mfreadwrite
-  Mfsensorgroup
-  shlwapi
-  runtimeobject
+  ${COMMON_LIBS}
   )
+
 
 target_link_libraries(msft_camera_node
   ${catkin_LIBRARIES}
-  win_camera
-  mf
-  mfplat
-  mfuuid
-  mfreadwrite
-  Mfsensorgroup
-  shlwapi
-  runtimeobject
-  RTPMediaStreamer 
-  RTSPServer
+  ${COMMON_LIBS}
+  ${RTSP_LIBS}
   )
 
 #############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,12 @@ include_directories(
   include
   ${catkin_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
+  external/Windows-Camera/Samples/NetworkMediaStreamer/Common/inc
   )
 
+#if(ENABLE_RTSP)
+include(external/CmakeLists.txt)
+#endif(ENABLE_RTSP)
 ## Declare a cpp library
 add_library(win_camera STATIC src/winrospublisher.cpp src/wincapture.cpp)
 
@@ -42,7 +46,7 @@ set_target_properties(msft_camera_nodelet PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 
 
 ## Declare a cpp executable
 add_executable(msft_camera_node src/msftcameranode.cpp)
-add_dependencies(msft_camera_node win_camera)
+add_dependencies(msft_camera_node win_camera RTPMediaStreamer RTSPServer)
 add_dependencies(msft_camera_nodelet win_camera)
 
 ## Specify libraries to link a library or executable target against
@@ -72,6 +76,8 @@ target_link_libraries(msft_camera_node
   Mfsensorgroup
   shlwapi
   runtimeobject
+  RTPMediaStreamer 
+  RTSPServer
   )
 
 #############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ include_directories(
   )
 
 if(ENABLE_RTSP)
+add_definitions(-DENABLE_RTSP)
 include(external/CmakeLists.txt)
 endif(ENABLE_RTSP)
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ To launch the node with streaming enabled, use the following command:
 ```
 roslaunch msft_camera_rtsp test/camnodeRTSP.launch
 ``` 
-Once the node with launched with RTSP enabled, you can view the video on any streaming video player that supports RTSP using the url:
-`rtsp://<ip-address-of-machine-running-the-node>:<rtsp_port>
-If using secure RTSP over TLS, use a video player that supports RTSPS with following url:
+After the node has been successfully launched with RTSP enabled, you can view the video on any streaming video player that supports RTSP using the url:  
+`rtsp://<ip-address-of-machine-running-the-node>:<rtsp_port>  
+If using secure RTSP over TLS, use a video player that supports RTSPS with following url:  
 `rtsps://<ip-address-of-machine-running-the-node>:<rtsp_port> 
 
 ## Published Topics

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ To launch the node with streaming enabled, use the following command:
 roslaunch msft_camera_rtsp test/camnodeRTSP.launch
 ``` 
 After the node has been successfully launched with RTSP enabled, you can view the video on any streaming video player that supports RTSP using the url:  
-`rtsp://<ip-address-of-machine-running-the-node>:<rtsp_port>  
+>rtsp://<ip-address-of-machine-running-the-node>:<rtsp_port>  
 
 If using secure RTSP over TLS, use a video player that supports RTSPS with following url:  
-`rtsps://<ip-address-of-machine-running-the-node>:<rtsp_port> 
+>rtsps://<ip-address-of-machine-running-the-node>:<rtsp_port> 
 
 ## Published Topics
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ For generic parameter usage example see [camnode.launch](test/camnode.launch)
 Only available if the source is built as per the [instructions for streaming](#camera-node-with-rtsprtp-streaming)  
   
   * `~rtsp_port` (integer, default: `8554`)
-    > The network port on which the RTSP server should listen for incoming connections.
-    > If this parameter is *not present* in the parameter server, then RTSP server is not started.
-    > If this parameter is *present and empty*, the RTSP server is started with the default port number 8554
+    > The network port on which the RTSP server should listen for incoming connections.  
+    > If this parameter is *not present* in the parameter server, then RTSP server is not started.  
+    > If this parameter is *present and empty*, the RTSP server is started with the default port number *8554*
 
   * `~rtp_bitrate` (integer, default: `1000*image_width`)
     > The bitrate in bps to configure the video encoder used for RTP streaming.
@@ -100,8 +100,10 @@ Only available if the source is built as per the [instructions for streaming](#c
     > A list containing old usernames to be removed from password vault to be used for RTSP digest authentication. 
 
   * `~rtsps_cert_subject` (string, default: ``)
-    > The certificate subject name to search in the "Local Machine\My" certificate store for RTSP**S** secure streaming over TLS.
-    > Note: to use RTSP**S** (secure RTSP over TLS), a valid server certificate must be imported to the "Local machine\My" certificate store.
+    > The certificate subject name to search in the "Local Machine\My" certificate store for RTSP**S** secure streaming over TLS.  
+    > Note: To use RTSP**S** (secure RTSP over TLS), a valid server certificate must be imported to the "Local machine\My" certificate store.  
+    > If this parameter is *not present*, the stream is not secure and RTSP and RTP communication will happen in the clear.  
+    > If this parameter is *present and valid*, RTSP communication will *only* happen securely over TLS. The remote client/player then has the ability to negotiate RTP via the secure TCP channel over RTSP protocol.
 
 For RTSP parameter usage example see [camnodeRTSP.launch](test/camnodeRTSP.launch)
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If using secure RTSP over TLS, use a video player that supports RTSPS with follo
 For generic parameter usage example see [camnode.launch](test/camnode.launch) 
 
 ### RTSP Streaming Parameters  
-Only available if the source is built as per the [instructions for streaming](#camera-node-with-rtsp/rtp-streaming)  
+Only available if the source is built as per the [instructions for streaming](#camera-node-with-rtsprtp-streaming)  
   
   * `~rtsp_port` (integer, default: `8554`)
     > The network port on which the RTSP server should listen for incoming connections.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ roslaunch msft_camera_rtsp test/camnodeRTSP.launch
 ``` 
 After the node has been successfully launched with RTSP enabled, you can view the video on any streaming video player that supports RTSP using the url:  
 `rtsp://<ip-address-of-machine-running-the-node>:<rtsp_port>  
+
 If using secure RTSP over TLS, use a video player that supports RTSPS with following url:  
 `rtsps://<ip-address-of-machine-running-the-node>:<rtsp_port> 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This source also contains a feature to stream out the captured video over RTSP/R
 The streaming feature supports the following:  
 - H.264 over RTP (session negotiation via RTSP)
 - RTSP digest and basic authentication 
-- RTSP over secure(TLS) connection (RTSPS)
+- RTSP over secure(TLS) connection (RTSPS)  
 The RTSP/RTP streaming related libraries are a part of a sub-module from the [Windows-Camera repository](https://github.com/microsoft/Windows-Camera/tree/release/NetworkVideoStreamer_1_0)
 For more details on streaming [visit this page](https://github.com/microsoft/Windows-Camera/blob/release/NetworkVideoStreamer_1_0/README.md)  
 
@@ -68,7 +68,7 @@ roslaunch msft_camera_rtsp test/camnodeRTSP.launch
     > Symbolic link to the camera to open. if not set default is the first enumerated camera on the system.
     > Set the Symbolic link to value "Interactive" to configure the node to list the available cameras on system and prompt for user selection at startup
 
-   * `~videoUrl` (string, default: ``)
+  * `~videoUrl` (string, default: ``)
     > Video URL to be used (instead of an actual camera device) as a source of video frames to be published by the node.
     > At present, file paths and rtsp urls are supported as video source. if both parameters, videoDeviceId and videoUrl, are set then videoDeviceId is used by the node.
 
@@ -78,7 +78,7 @@ roslaunch msft_camera_rtsp test/camnodeRTSP.launch
 For generic parameter usage example see [camnode.launch](test/camnode.launch) 
 
 ### RTSP Streaming Parameters  
-    Only available if the source is built as per the [instructions for streaming](#camera-node-with-RTSP/RTP-streaming)  
+Only available if the source is built as per the [instructions for streaming](#camera-node-with-RTSP/RTP-streaming)  
   
   * `~rtsp_port` (integer, default: `8554`)
     > The network port on which the RTSP server should listen for incoming connections.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ The node publishes image frames using image_transport camera publisher on a `ima
 This source also contains camera nodelet to enable sharing IMFSample pointers directly into another nodelet with the same process to enable zero copy and also share GPU surfaces
 This is enabled by using the MFSample Publisher which published IMFSample pointer via a custom msg. This path is still experimental and untested.
 
+This source also contains feature to stream the video over RTSP/RTP using H.264 video compression.
+The RTSP/RTP streaming code is a sub-module from the [Windows-Camera repository](https://github.com/microsoft/Windows-Camera/tree/release/NetworkVideoStreamer_1_0)
 ## System Requirement
 
   * Microsoft Windows 10 64-bit
@@ -21,6 +23,23 @@ You can begin with the below launch file. It will bring up RViz tool where you c
 ```
 roslaunch msft_camera test/camnode.launch
 ```
+
+To enable RTSP streaming you will need to create a recursive clone of this repository using the following command:  
+```
+git clone https://github.com/ms-iot/ros_msft_camera --recursive
+```
+
+Then at the top level folder (i.e. parallel to the src folder) use the command  
+
+```
+catkin_make -DENABLE_RTSP=1
+```
+This will build the node with RTP/RTSP streaming capability. 
+To launch the node with streaming enabled, use the following command:
+
+```
+roslaunch msft_camera_rtsp test/camnodeRTSP.launch
+``` 
 
 ## Published Topics
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ To launch the node with streaming enabled, use the following command:
 roslaunch msft_camera_rtsp test/camnodeRTSP.launch
 ``` 
 After the node has been successfully launched with RTSP enabled, you can view the video on any streaming video player that supports RTSP using the url:  
->rtsp://<ip-address-of-machine-running-the-node>:<rtsp_port>  
+> `rtsp://<ip-address-of-machine-running-the-node>:<rtsp_port>`
 
 If using secure RTSP over TLS, use a video player that supports RTSPS with following url:  
->rtsps://<ip-address-of-machine-running-the-node>:<rtsp_port> 
+> `rtsps://<ip-address-of-machine-running-the-node>:<rtsp_port>` 
 
 ## Published Topics
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ To launch the node with streaming enabled, use the following command:
 ```
 roslaunch msft_camera_rtsp test/camnodeRTSP.launch
 ``` 
+Once the node with launched with RTSP enabled, you can view the video on any streaming video player that supports RTSP using the url:
+`rtsp://<ip-address-of-machine-running-the-node>:<rtsp_port>
+If using secure RTSP over TLS, use a video player that supports RTSPS with following url:
+`rtsps://<ip-address-of-machine-running-the-node>:<rtsp_port> 
 
 ## Published Topics
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If using secure RTSP over TLS, use a video player that supports RTSPS with follo
 For generic parameter usage example see [camnode.launch](test/camnode.launch) 
 
 ### RTSP Streaming Parameters  
-Only available if the source is built as per the [instructions for streaming](#camera-node-with-RTSP/RTP-streaming)  
+Only available if the source is built as per the [instructions for streaming](#camera-node-with-rtsp/rtp-streaming)  
   
   * `~rtsp_port` (integer, default: `8554`)
     > The network port on which the RTSP server should listen for incoming connections.

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 3.15.3)
+#project(NetworkMediaStreamer)
+
+set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD_REQUIRED TRUE)
+set (CMAKE_CXX_EXTENSIONS FALSE)
+
+add_library(NetworkMediaStreamerBase STATIC 
+${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/NetworkMediaStreamerBase/src/NwMediaStreamSinkBase.cpp)
+
+add_library(RTPMediaStreamer SHARED
+${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/RTPMediaStreamer/src/RTPMediaSink.cpp
+${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/RTPMediaStreamer/src/RTPStreamSink.cpp)
+
+add_library(RTSPServer SHARED
+${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/RTSPServer/src/RTSPAuthProvider.cpp
+${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/RTSPServer/src/RTSPServer.cpp
+${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/RTSPServer/src/RtspSession.cpp
+${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/RTSPServer/src/SocketWrapper.cpp)
+
+target_compile_definitions(RTPMediaStreamer PRIVATE RTPMEDIASTREAMER_EXPORTS)
+target_compile_definitions(RTSPServer PRIVATE RTSPSERVER_EXPORTS)
+
+target_include_directories(NetworkMediaStreamerBase PRIVATE 
+${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/Common/inc
+${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/NetworkMediaStreamerBase/inc)
+
+# The order of the include directories is super-important, because dependancy directories may have a pch.h (meant for the dependancy lib) 
+# and the first one in the list is chosen. So make sure the include directory for the correct pch.h comes first 
+target_include_directories(RTPMediaStreamer PRIVATE 
+${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/Common/inc
+${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/RTPMediaStreamer/inc
+${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/NetworkMediaStreamerBase/inc
+)
+
+target_include_directories(RTSPServer PRIVATE 
+${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/Common/inc
+${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/RTSPServer/inc)
+
+add_dependencies(RTSPServer RTPMediaStreamer)
+add_dependencies(RTPMediaStreamer NetworkMediaStreamerBase)
+
+set(COMMONLIBS 
+  mf
+  mfplat
+  mfuuid
+  mfreadwrite
+  runtimeobject
+  ws2_32) 
+  
+target_link_libraries(RTSPServer ${COMMONLIBS} Secur32 Crypt32)
+target_link_libraries(RTPMediaStreamer ${COMMONLIBS} NetworkMediaStreamerBase)
+
+
+

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -18,8 +18,8 @@ ${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/RTSPSer
 ${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/RTSPServer/src/RtspSession.cpp
 ${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/RTSPServer/src/SocketWrapper.cpp)
 
-target_compile_definitions(RTPMediaStreamer PRIVATE RTPMEDIASTREAMER_EXPORTS)
-target_compile_definitions(RTSPServer PRIVATE RTSPSERVER_EXPORTS)
+target_compile_definitions(RTPMediaStreamer PRIVATE RTPMEDIASTREAMER_EXPORTS UNICODE)
+target_compile_definitions(RTSPServer PRIVATE RTSPSERVER_EXPORTS UNICODE)
 
 target_include_directories(NetworkMediaStreamerBase PRIVATE 
 ${CMAKE_CURRENT_SOURCE_DIR}/external/Windows-Camera/NetworkMediaStreamer/Common/inc

--- a/src/msftcameranode.cpp
+++ b/src/msftcameranode.cpp
@@ -4,6 +4,16 @@
 #include <ros/ros.h>
 #include <string>
 
+#include <EventToken.h>
+#include <windows.h>
+#include <wincrypt.h>
+#include <windows.foundation.h>
+#include <windows.foundation.collections.h>
+#include <winrt\base.h>
+#include <winrt\Windows.Media.h>
+#include <winrt\Windows.Foundation.h>
+#include "RTSPServerControl.h"
+#include "RTPMediaStreamer.h"
 using namespace winrt::Windows::System::Threading;
 using namespace winrt::Windows::Foundation;
 using namespace ros_msft_camera;
@@ -11,7 +21,152 @@ constexpr int32_t PUBLISHER_QUEUE_SIZE = 4;
 constexpr int32_t DEFAULT_WIDTH = 640;
 constexpr int32_t DEFAULT_HEIGHT = 480;
 constexpr float DEFAULT_FRAMERATE = 30.0;
+constexpr int32_t DEFAULT_RTSP_PORT = 8554;
 auto videoFormat = MFVideoFormat_ARGB32;
+
+IMFSinkWriter* InitSinkWriter(IMFMediaSink* pMediaSink, uint32_t width, uint32_t height, float framerate, GUID subType)
+{
+    com_ptr<IMFSinkWriter> spSinkWriter;
+    com_ptr<IMFAttributes> spSWAttributes;
+    winrt::com_ptr<IMFMediaType> spInType;
+    std::map<hstring, GUID> subtypeMap =
+    {
+        {L"NV12", MFVideoFormat_NV12},
+        {L"YUY2", MFVideoFormat_YUY2},
+        {L"IYUV", MFVideoFormat_IYUV},
+        {L"ARGB32", MFVideoFormat_ARGB32}
+    };
+
+    check_hresult(MFCreateMediaType(spInType.put()));
+    check_hresult(MFSetAttributeSize(spInType.get(), MF_MT_FRAME_SIZE, width, height));
+    check_hresult(MFSetAttributeRatio(spInType.get(), MF_MT_FRAME_RATE, (uint32_t)(framerate * 100), 100));
+
+    check_hresult(spInType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video));
+    check_hresult(spInType->SetGUID(MF_MT_SUBTYPE, subType));
+
+    check_hresult(MFCreateAttributes(spSWAttributes.put(), 2));
+    check_hresult(spSWAttributes->SetUINT32(MF_LOW_LATENCY, TRUE));
+    HRESULT hr = S_OK;
+    BOOL bEnableHWTransforms = FALSE;
+    do
+    {
+        spSinkWriter = nullptr;
+        check_hresult(spSWAttributes->SetUINT32(MF_READWRITE_ENABLE_HARDWARE_TRANSFORMS, bEnableHWTransforms));
+        check_hresult(MFCreateSinkWriterFromMediaSink(pMediaSink, spSWAttributes.get(), spSinkWriter.put()));
+        hr = spSinkWriter->SetInputMediaType(0, spInType.get(), nullptr);
+        bEnableHWTransforms = !bEnableHWTransforms;
+    } while (hr == MF_E_TOPO_CODEC_NOT_FOUND);
+    check_hresult(hr);
+    check_hresult(spSinkWriter->BeginWriting());
+
+    return spSinkWriter.detach();
+}
+
+IRTSPAuthProvider* SetupRTSPAuthentication(ros::NodeHandle* pPrivateNode)
+{
+    winrt::com_ptr<IRTSPAuthProvider> spAuthProvider;
+    std::map<std::string, std::string> credsAdd;
+    std::vector<std::string> credsRemove;
+    pPrivateNode->param("rtsp_AddCredentials", credsAdd, credsAdd);
+    pPrivateNode->param("rtsp_RemoveCredentials", credsRemove, credsRemove);
+    winrt::check_hresult(GetAuthProviderInstance(AuthType::Digest, winrt::to_hstring(pPrivateNode->getNamespace()).c_str(), spAuthProvider.put()));
+    auto spCredStore = spAuthProvider.as<IRTSPAuthProviderCredStore>();
+    for (auto&& user : credsRemove)
+    {
+        winrt::check_hresult(spCredStore->RemoveUser(winrt::to_hstring(user).c_str()));
+    }
+    for (auto&& cred : credsAdd)
+    {
+        auto user = winrt::to_hstring(cred.first);
+        auto pass = winrt::to_hstring(cred.second);
+        winrt::check_hresult(spCredStore->AddUser(user.c_str(), pass.c_str()));
+    }
+
+    return spAuthProvider.detach();
+}
+IMFSinkWriter* SetupRTSPServer(uint32_t width, uint32_t height, float framerate, GUID inSubType, ros::NodeHandle* pPrivateNode, IRTSPServerControl** ppServerControl)
+{
+    winrt::com_ptr<IMFMediaType> spOutMT;
+    winrt::com_ptr<IMFMediaSink> spMediaSink;
+    winrt::com_ptr<IRTSPServerControl> spServerControl;
+    PCCERT_CONTEXT pCert = nullptr;
+    int rtspPort = DEFAULT_RTSP_PORT;
+    std::string secureCertFile = "";
+    int bitRate = width * 1000;
+
+    pPrivateNode->param("rtsp_port", rtspPort, rtspPort);
+    pPrivateNode->param("rtsps_cert_filepath", secureCertFile, secureCertFile);
+    pPrivateNode->param("rtp_bitrate", bitRate, bitRate);
+
+    MFCreateMediaType(spOutMT.put());
+    check_hresult(MFSetAttributeSize(spOutMT.get(), MF_MT_FRAME_SIZE, width, height));
+    check_hresult(MFSetAttributeRatio(spOutMT.get(), MF_MT_FRAME_RATE, (uint32_t)(framerate * 100), 100));
+    winrt::check_hresult(spOutMT->SetUINT32(MF_MT_AVG_BITRATE, bitRate));
+
+    winrt::check_hresult(spOutMT->SetUINT32(MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive));
+    check_hresult(spOutMT->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video));
+    check_hresult(spOutMT->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_H264));
+
+    IMFMediaType* mts[1];
+    mts[0] = spOutMT.get();
+    winrt::check_hresult(CreateRTPMediaSink(mts, 1, spMediaSink.put()));
+    auto pSinkWriter = InitSinkWriter(spMediaSink.get(), width, height, framerate, inSubType);
+    winrt::RTSPSuffixSinkMap rtspMap;
+    rtspMap.Insert(L"/", spMediaSink.as<winrt::Windows::Foundation::IInspectable>());
+    if (!secureCertFile.empty())
+    {
+
+        FILE* fp = fopen(secureCertFile.c_str(), "rb");
+        fseek(fp, 0, SEEK_END);
+        auto sz = ftell(fp);
+        fseek(fp, 0, SEEK_SET);
+        std::unique_ptr<BYTE[]>  certData = std::make_unique<BYTE[]>(sz);
+        if (fread(certData.get(), sz, 1, fp) > 0)
+        {
+            pCert = CertCreateCertificateContext(X509_ASN_ENCODING, certData.get(), sz);
+        }
+    }
+    winrt::com_ptr<IRTSPAuthProvider> spAuthProvider;
+    spAuthProvider.attach(SetupRTSPAuthentication(pPrivateNode));
+    winrt::check_hresult(CreateRTSPServer(rtspMap.as<ABI::RTSPSuffixSinkMap>().get(), rtspPort, (pCert != nullptr), spAuthProvider.get(),&pCert, pCert?1:0, spServerControl.put()));
+
+    *ppServerControl = spServerControl.detach();
+    return pSinkWriter;
+}
+
+std::string FormatUrl(std::string cameraInfoUrl)
+{
+    auto pos = cameraInfoUrl.find("file:");
+    if (pos != std::string::npos)
+    {
+        // this block of code is required because there is a bug in camerainfo manager url based api 
+        // when handling file:// prefix url with local paths like "e:\folder"
+        // We convert such paths to unc path.
+
+        pos += 5; // length of "file:"
+        int slashCnt = 0;
+        while (cameraInfoUrl[++pos] == '/') slashCnt++;
+        if (cameraInfoUrl[pos] == '\\' && cameraInfoUrl[pos + 1] == '\\')
+        {
+            // unc path that needs conversion
+            auto path = cameraInfoUrl.substr(pos + 2);
+            cameraInfoUrl = std::string("file:////") + path;
+        }
+        else if (cameraInfoUrl[pos + 1] == ':')
+        {
+            //full drive path
+            auto path = cameraInfoUrl.substr(pos);
+            path[1] = '$'; // replace ':' with '$' to convert to unc path
+            cameraInfoUrl = std::string("file:////127.0.0.1\\") + path;
+        }
+        else if (slashCnt < 4) // if slashCnt >= 4 it is probably is an acceptable unc path
+        {
+            ROS_ERROR("camera info url for file must be a fully qualified drive path or unc path");
+        }
+    }
+    return cameraInfoUrl;
+}
+
 int main(int argc, char** argv)
 {
     try
@@ -45,67 +200,43 @@ int main(int argc, char** argv)
             }
             else
             {
-                int i = 0;
-#ifdef INTERACTIVE
-                std::map< std::string, ros::console::levels::Level> logger;
-                ros::console::get_loggers(logger);
-                if (logger[ROSCONSOLE_DEFAULT_NAME] == ros::console::levels::Level::Info)
-                {
-                    for (auto sym : ros_msft_camera::WindowsMFCapture::EnumerateCameraLinks(false))
-                    {
-                        ROS_INFO("%d. %s", i++, sym.c_str());
-                    }
-                    ROS_INFO("\nYour choice: ");
-                    std::cin >> i;
-                }
-                else
-                {
-                    ROS_ERROR("\nINTERATIVE mode for camera selection needs logger levels set atleast to Level::Info");
-                }
-#endif
                 // no source path is specified; we default to first enumerated camera
-                videoSourcePath = winrt::to_string(ros_msft_camera::WindowsMFCapture::EnumerateCameraLinks(false).GetAt(i));
+                videoSourcePath = winrt::to_string(ros_msft_camera::WindowsMFCapture::EnumerateCameraLinks(false).GetAt(0));
+            }
+        }
+        else if (videoSourcePath == "Interactive")
+        {
+            int i = 1;
+            std::map< std::string, ros::console::levels::Level> logger;
+            ros::console::get_loggers(logger);
+            if (logger[ROSCONSOLE_DEFAULT_NAME] == ros::console::levels::Level::Info)
+            {
+                for (auto sym : ros_msft_camera::WindowsMFCapture::EnumerateCameraLinks(false))
+                {
+                    ROS_INFO("%d. %s", i++, sym.c_str());
+                }
+                ROS_INFO("\nYour choice: ");
+                std::cin >> i;
+                videoSourcePath = winrt::to_string(ros_msft_camera::WindowsMFCapture::EnumerateCameraLinks(false).GetAt(i - 1));
+            }
+            else
+            {
+                ROS_ERROR("\nINTERATIVE mode for camera selection needs logger levels set atleast to Level::Info");
             }
         }
         std::shared_ptr<camera_info_manager::CameraInfoManager> spCameraInfoManager = std::make_shared<camera_info_manager::CameraInfoManager>(privateNode, frame_id, "");
         if (privateNode.getParam("camera_info_url", cameraInfoUrl))
         {
-            auto pos = cameraInfoUrl.find("file:");
-            if (pos != std::string::npos)
-            {
-                // this block of code is required because there is a bug in camerainfo manager url based api 
-                // when handling file:// prefix url with local paths like "e:\folder"
-                // We convert such paths to unc path.
-
-                pos += 5; // length of "file:"
-                int slashCnt = 0;
-                while (cameraInfoUrl[++pos] == '/') slashCnt++;
-                if (cameraInfoUrl[pos] == '\\' && cameraInfoUrl[pos + 1] == '\\')
-                {
-                    // unc path that needs conversion
-                    auto path = cameraInfoUrl.substr(pos + 2);
-                    cameraInfoUrl = std::string("file:////") + path;
-                }
-                else if (cameraInfoUrl[pos + 1] == ':')
-                {
-                    //full drive path
-                    auto path = cameraInfoUrl.substr(pos);
-                    path[1] = '$'; // replace ':' with '$' to convert to unc path
-                    cameraInfoUrl = std::string("file:////127.0.0.1\\") + path;
-                }
-                else if (slashCnt < 4) // if slashCnt >= 4 it is probably is an acceptable unc path
-                {
-                    ROS_ERROR("camera info url for file must be a fully qualified drive path or unc path");
-                }
-            }
-
+            cameraInfoUrl = FormatUrl(cameraInfoUrl);
             if (spCameraInfoManager->validateURL(cameraInfoUrl))
             {
                 ROS_INFO("validated Camera info url: %s", cameraInfoUrl.c_str());
                 spCameraInfoManager->loadCameraInfo(cameraInfoUrl);
             }
         }
-        //camera.attach(WindowsMFCapture::CreateInstance(isDevice, winrt::to_hstring(videoSourcePath)));
+
+        winrt::com_ptr<IMFSinkWriter> spSinkWriter;
+        winrt::com_ptr<IRTSPServerControl> spRTSPServer;
         auto rawPublisher = new WinRosPublisherImageRaw(privateNode, "image_raw", queueSize, frame_id, spCameraInfoManager.get());
 
         bool resChangeInProgress = false;
@@ -135,6 +266,7 @@ int main(int argc, char** argv)
                 else
                 {
                     rawPublisher->OnSample(pSample, (UINT32)Width, (UINT32)Height);
+                    spSinkWriter? winrt::check_hresult(spSinkWriter->WriteSample(0, pSample)) : 0;
                 }
             }
             else
@@ -146,7 +278,7 @@ int main(int argc, char** argv)
                     camera->RemoveSampleHandler(imagePubHandlerToken);
                     camera = nullptr;
                     camera.attach(WindowsMFCapture::CreateInstance(isDevice, winrt::to_hstring(videoSourcePath), false));
-                    
+
                     camera->ChangeCaptureConfig(Width, Height, frameRate, videoFormat, true);
                     camera->StartStreaming();
                     imagePubHandlerToken = camera->AddSampleHandler(rosImagePubHandler);
@@ -163,8 +295,30 @@ int main(int argc, char** argv)
 
         camera.attach(WindowsMFCapture::CreateInstance(isDevice, winrt::to_hstring(videoSourcePath), true));
         camera->ChangeCaptureConfig(Width, Height, frameRate, videoFormat, true);
+        if (privateNode.hasParam("rtsp_port"))
+        {
+            spSinkWriter.attach(SetupRTSPServer(Width, Height, frameRate, videoFormat, &privateNode, spRTSPServer.put()));
+            winrt::LogHandler rtsplogger([](winrt::hresult hr, winrt::hstring msg)
+                {
+                    if (SUCCEEDED(hr.value))
+                    {
+                        ROS_INFO("%s", winrt::to_string(msg).c_str());
+                    }
+                    else
+                    {
+                        ROS_ERROR("%x:%s\n", hr.value, winrt::to_string(msg).c_str());
+                    }
+                });
+            for (int l = (int)LoggerType::ERRORS; l < (int)LoggerType::LOGGER_MAX; l++)
+            {
+                EventRegistrationToken t;
+                spRTSPServer->AddLogHandler((LoggerType)l, rtsplogger.as<ABI::LogHandler>().get(), &t);
+            }
+            spRTSPServer->StartServer();
+        }
         camera->StartStreaming();
         imagePubHandlerToken = camera->AddSampleHandler(rosImagePubHandler);
+        
 
 #ifdef TEST_SETCAMERAINFO
         Sleep(10000);

--- a/src/msftcameranode.cpp
+++ b/src/msftcameranode.cpp
@@ -22,282 +22,204 @@ constexpr int32_t DEFAULT_WIDTH = 640;
 constexpr int32_t DEFAULT_HEIGHT = 480;
 constexpr float DEFAULT_FRAMERATE = 30.0;
 constexpr int32_t DEFAULT_RTSP_PORT = 8554;
-auto videoFormat = MFVideoFormat_ARGB32;
+const GUID g_rosPrefferdVideoFormat = MFVideoFormat_ARGB32;
+const GUID g_rtspPrefferdVideoFormat = MFVideoFormat_NV12;
 
-IMFSinkWriter* InitSinkWriter(IMFMediaSink* pMediaSink, uint32_t width, uint32_t height, float framerate, GUID subType)
+//#define ENABLE_RTSP
+class MsftCameraNode : ros::NodeHandle
 {
-    com_ptr<IMFSinkWriter> spSinkWriter;
-    com_ptr<IMFAttributes> spSWAttributes;
-    winrt::com_ptr<IMFMediaType> spInType;
-    std::map<hstring, GUID> subtypeMap =
+public:
+    MsftCameraNode(std::string ns)
+        : ros::NodeHandle(ns)
     {
-        {L"NV12", MFVideoFormat_NV12},
-        {L"YUY2", MFVideoFormat_YUY2},
-        {L"IYUV", MFVideoFormat_IYUV},
-        {L"ARGB32", MFVideoFormat_ARGB32}
-    };
-
-    check_hresult(MFCreateMediaType(spInType.put()));
-    check_hresult(MFSetAttributeSize(spInType.get(), MF_MT_FRAME_SIZE, width, height));
-    check_hresult(MFSetAttributeRatio(spInType.get(), MF_MT_FRAME_RATE, (uint32_t)(framerate * 100), 100));
-
-    check_hresult(spInType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video));
-    check_hresult(spInType->SetGUID(MF_MT_SUBTYPE, subType));
-
-    check_hresult(MFCreateAttributes(spSWAttributes.put(), 2));
-    check_hresult(spSWAttributes->SetUINT32(MF_LOW_LATENCY, TRUE));
-    HRESULT hr = S_OK;
-    BOOL bEnableHWTransforms = FALSE;
-    do
-    {
-        spSinkWriter = nullptr;
-        check_hresult(spSWAttributes->SetUINT32(MF_READWRITE_ENABLE_HARDWARE_TRANSFORMS, bEnableHWTransforms));
-        check_hresult(MFCreateSinkWriterFromMediaSink(pMediaSink, spSWAttributes.get(), spSinkWriter.put()));
-        hr = spSinkWriter->SetInputMediaType(0, spInType.get(), nullptr);
-        bEnableHWTransforms = !bEnableHWTransforms;
-    } while (hr == MF_E_TOPO_CODEC_NOT_FOUND);
-    check_hresult(hr);
-    check_hresult(spSinkWriter->BeginWriting());
-
-    return spSinkWriter.detach();
-}
-
-IRTSPAuthProvider* SetupRTSPAuthentication(ros::NodeHandle* pPrivateNode)
-{
-    winrt::com_ptr<IRTSPAuthProvider> spAuthProvider;
-    std::map<std::string, std::string> credsAdd;
-    std::vector<std::string> credsRemove;
-    pPrivateNode->param("rtsp_AddCredentials", credsAdd, credsAdd);
-    pPrivateNode->param("rtsp_RemoveCredentials", credsRemove, credsRemove);
-    winrt::check_hresult(GetAuthProviderInstance(AuthType::Digest, winrt::to_hstring(pPrivateNode->getNamespace()).c_str(), spAuthProvider.put()));
-    auto spCredStore = spAuthProvider.as<IRTSPAuthProviderCredStore>();
-    for (auto&& user : credsRemove)
-    {
-        winrt::check_hresult(spCredStore->RemoveUser(winrt::to_hstring(user).c_str()));
-    }
-    for (auto&& cred : credsAdd)
-    {
-        auto user = winrt::to_hstring(cred.first);
-        auto pass = winrt::to_hstring(cred.second);
-        winrt::check_hresult(spCredStore->AddUser(user.c_str(), pass.c_str()));
-    }
-
-    return spAuthProvider.detach();
-}
-IMFSinkWriter* SetupRTSPServer(uint32_t width, uint32_t height, float framerate, GUID inSubType, ros::NodeHandle* pPrivateNode, IRTSPServerControl** ppServerControl)
-{
-    winrt::com_ptr<IMFMediaType> spOutMT;
-    winrt::com_ptr<IMFMediaSink> spMediaSink;
-    winrt::com_ptr<IRTSPServerControl> spServerControl;
-    PCCERT_CONTEXT pCert = nullptr;
-    int rtspPort = DEFAULT_RTSP_PORT;
-    std::string secureCertFile = "";
-    int bitRate = width * 1000;
-
-    pPrivateNode->param("rtsp_port", rtspPort, rtspPort);
-    pPrivateNode->param("rtsps_cert_filepath", secureCertFile, secureCertFile);
-    pPrivateNode->param("rtp_bitrate", bitRate, bitRate);
-
-    MFCreateMediaType(spOutMT.put());
-    check_hresult(MFSetAttributeSize(spOutMT.get(), MF_MT_FRAME_SIZE, width, height));
-    check_hresult(MFSetAttributeRatio(spOutMT.get(), MF_MT_FRAME_RATE, (uint32_t)(framerate * 100), 100));
-    winrt::check_hresult(spOutMT->SetUINT32(MF_MT_AVG_BITRATE, bitRate));
-
-    winrt::check_hresult(spOutMT->SetUINT32(MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive));
-    check_hresult(spOutMT->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video));
-    check_hresult(spOutMT->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_H264));
-
-    IMFMediaType* mts[1];
-    mts[0] = spOutMT.get();
-    winrt::check_hresult(CreateRTPMediaSink(mts, 1, spMediaSink.put()));
-    auto pSinkWriter = InitSinkWriter(spMediaSink.get(), width, height, framerate, inSubType);
-    winrt::RTSPSuffixSinkMap rtspMap;
-    rtspMap.Insert(L"/", spMediaSink.as<winrt::Windows::Foundation::IInspectable>());
-    if (!secureCertFile.empty())
-    {
-
-        FILE* fp = fopen(secureCertFile.c_str(), "rb");
-        fseek(fp, 0, SEEK_END);
-        auto sz = ftell(fp);
-        fseek(fp, 0, SEEK_SET);
-        std::unique_ptr<BYTE[]>  certData = std::make_unique<BYTE[]>(sz);
-        if (fread(certData.get(), sz, 1, fp) > 0)
+        param("frame_rate", m_frameRate, m_frameRate);
+        param("pub_queue_size", m_queueSize, m_queueSize);
+        param("image_width", m_width, DEFAULT_WIDTH);
+        param("image_height", m_height, DEFAULT_HEIGHT);
+        param("frame_id", m_frameId, std::string("camera"));
+        getParam("videoDeviceId", m_videoSourcePath);
+        if (m_videoSourcePath.empty())
         {
-            pCert = CertCreateCertificateContext(X509_ASN_ENCODING, certData.get(), sz);
-        }
-    }
-    winrt::com_ptr<IRTSPAuthProvider> spAuthProvider;
-    spAuthProvider.attach(SetupRTSPAuthentication(pPrivateNode));
-    winrt::check_hresult(CreateRTSPServer(rtspMap.as<ABI::RTSPSuffixSinkMap>().get(), rtspPort, (pCert != nullptr), spAuthProvider.get(),&pCert, pCert?1:0, spServerControl.put()));
-
-    *ppServerControl = spServerControl.detach();
-    return pSinkWriter;
-}
-
-std::string FormatUrl(std::string cameraInfoUrl)
-{
-    auto pos = cameraInfoUrl.find("file:");
-    if (pos != std::string::npos)
-    {
-        // this block of code is required because there is a bug in camerainfo manager url based api 
-        // when handling file:// prefix url with local paths like "e:\folder"
-        // We convert such paths to unc path.
-
-        pos += 5; // length of "file:"
-        int slashCnt = 0;
-        while (cameraInfoUrl[++pos] == '/') slashCnt++;
-        if (cameraInfoUrl[pos] == '\\' && cameraInfoUrl[pos + 1] == '\\')
-        {
-            // unc path that needs conversion
-            auto path = cameraInfoUrl.substr(pos + 2);
-            cameraInfoUrl = std::string("file:////") + path;
-        }
-        else if (cameraInfoUrl[pos + 1] == ':')
-        {
-            //full drive path
-            auto path = cameraInfoUrl.substr(pos);
-            path[1] = '$'; // replace ':' with '$' to convert to unc path
-            cameraInfoUrl = std::string("file:////127.0.0.1\\") + path;
-        }
-        else if (slashCnt < 4) // if slashCnt >= 4 it is probably is an acceptable unc path
-        {
-            ROS_ERROR("camera info url for file must be a fully qualified drive path or unc path");
-        }
-    }
-    return cameraInfoUrl;
-}
-
-int main(int argc, char** argv)
-{
-    try
-    {
-        ros::init(argc, argv, "msft_camera");
-        ros::NodeHandle privateNode("~");
-        std::string videoSourcePath = "";
-        bool isDevice = true;
-        float frameRate = 30;
-        int32_t queueSize = PUBLISHER_QUEUE_SIZE;
-        winrt::com_ptr< ros_msft_camera::WindowsMFCapture> camera;
-        winrt::event_token imagePubHandlerToken;
-        std::string frame_id("camera");
-        privateNode.param("frame_rate", frameRate, DEFAULT_FRAMERATE);
-        privateNode.param("pub_queue_size", queueSize, PUBLISHER_QUEUE_SIZE);
-        std::condition_variable eventFinish;
-        int32_t Width(DEFAULT_WIDTH), Height(DEFAULT_HEIGHT);
-        std::string cameraInfoUrl("");
-        privateNode.param("image_width", Width, DEFAULT_WIDTH);
-        privateNode.param("image_height", Height, DEFAULT_HEIGHT);
-
-        privateNode.param("frame_id", frame_id, std::string("camera"));
-
-        privateNode.getParam("videoDeviceId", videoSourcePath);
-        if (videoSourcePath.empty())
-        {
-            privateNode.getParam("videoUrl", videoSourcePath);
-            if (!videoSourcePath.empty())
+            getParam("videoUrl", m_videoSourcePath);
+            if (!m_videoSourcePath.empty())
             {
-                isDevice = false;
+                m_isDevice = false;
             }
             else
             {
                 // no source path is specified; we default to first enumerated camera
-                videoSourcePath = winrt::to_string(ros_msft_camera::WindowsMFCapture::EnumerateCameraLinks(false).GetAt(0));
+                m_videoSourcePath = winrt::to_string(ros_msft_camera::WindowsMFCapture::EnumerateCameraLinks(false).GetAt(0));
             }
         }
-        else if (videoSourcePath == "Interactive")
+
+        else if (m_videoSourcePath == "Interactive")
         {
             int i = 1;
             std::map< std::string, ros::console::levels::Level> logger;
             ros::console::get_loggers(logger);
             if (logger[ROSCONSOLE_DEFAULT_NAME] == ros::console::levels::Level::Info)
             {
-                for (auto sym : ros_msft_camera::WindowsMFCapture::EnumerateCameraLinks(false))
+                auto links = ros_msft_camera::WindowsMFCapture::EnumerateCameraLinks(false);
+                for (auto sym : links)
                 {
                     ROS_INFO("%d. %s", i++, sym.c_str());
                 }
-                ROS_INFO("\nYour choice: ");
-                std::cin >> i;
-                videoSourcePath = winrt::to_string(ros_msft_camera::WindowsMFCapture::EnumerateCameraLinks(false).GetAt(i - 1));
+                do
+                {
+                    ROS_INFO("\nYour choice [1 to %d]: ", links.Size());
+                    std::cin >> i;
+                } while ((i < 1) || (i > links.Size()));
+                m_videoSourcePath = winrt::to_string(links.GetAt(i - 1));
             }
             else
             {
-                ROS_ERROR("\nINTERATIVE mode for camera selection needs logger levels set atleast to Level::Info");
-            }
-        }
-        std::shared_ptr<camera_info_manager::CameraInfoManager> spCameraInfoManager = std::make_shared<camera_info_manager::CameraInfoManager>(privateNode, frame_id, "");
-        if (privateNode.getParam("camera_info_url", cameraInfoUrl))
-        {
-            cameraInfoUrl = FormatUrl(cameraInfoUrl);
-            if (spCameraInfoManager->validateURL(cameraInfoUrl))
-            {
-                ROS_INFO("validated Camera info url: %s", cameraInfoUrl.c_str());
-                spCameraInfoManager->loadCameraInfo(cameraInfoUrl);
+                ROS_ERROR("\nINTERACTIVE mode for camera selection needs logger levels set atleast to Level::Info");
             }
         }
 
-        winrt::com_ptr<IMFSinkWriter> spSinkWriter;
-        winrt::com_ptr<IRTSPServerControl> spRTSPServer;
-        auto rawPublisher = new WinRosPublisherImageRaw(privateNode, "image_raw", queueSize, frame_id, spCameraInfoManager.get());
-
-        bool resChangeInProgress = false;
-        winrt::delegate<winrt::hresult_error, winrt::hstring, IMFSample*> rosImagePubHandler = [&](winrt::hresult_error ex, winrt::hstring msg, IMFSample* pSample)
+        m_spCameraInfoManager = std::make_shared<camera_info_manager::CameraInfoManager>((ros::NodeHandle) * this, m_frameId, "");
+        if (getParam("camera_info_url", m_cameraInfoUrl))
         {
-            if (pSample)
+            m_cameraInfoUrl = FormatUrl(m_cameraInfoUrl);
+            if (m_spCameraInfoManager->validateURL(m_cameraInfoUrl))
             {
-                auto info = spCameraInfoManager->getCameraInfo();
-                if (((info.height != Height) || (info.width != Width)) && info.height && info.width && (!resChangeInProgress))
-                {
-                    resChangeInProgress = true;
-                    ThreadPool::RunAsync([camera, &Width, &Height, frameRate, spCameraInfoManager, &resChangeInProgress](IAsyncAction)
-                        {
-                            auto info = spCameraInfoManager->getCameraInfo();
-                            if (camera->ChangeCaptureConfig(info.width, info.height, frameRate, videoFormat, true))
-                            {
-                                Height = info.height;
-                                Width = info.width;
-                                resChangeInProgress = false;
-                            }
-                            else
-                            {
-                                ROS_WARN("Setting resolution  failed. Use rescale_camera_info param for rescaling");
-                            }
-                        });
-                }
-                else
-                {
-                    rawPublisher->OnSample(pSample, (UINT32)Width, (UINT32)Height);
-                    spSinkWriter? winrt::check_hresult(spSinkWriter->WriteSample(0, pSample)) : 0;
-                }
+                ROS_INFO("validated Camera info url: %s", m_cameraInfoUrl.c_str());
+                m_spCameraInfoManager->loadCameraInfo(m_cameraInfoUrl);
+            }
+        }
+
+        m_spRawImagePublisher = std::make_unique<WinRosPublisherImageRaw>(*((ros::NodeHandle *)this), "image_raw", m_queueSize, m_frameId, m_spCameraInfoManager);
+        ConfigureMFCapture(true);
+    }
+
+    virtual ~MsftCameraNode()
+    {
+        Stop();
+    }
+    void Start()
+    {
+        m_spWinMFCaptureRos->StartStreaming();
+        m_imagePubHandlerToken = m_spWinMFCaptureRos->AddSampleHandler({ this, &MsftCameraNode::ImagePubHandler });
+
+#ifdef TEST_SETCAMERAINFO
+        Sleep(10000);
+        auto info = m_spCameraInfoManager->getCameraInfo();
+        info.height = 720;
+        info.width = 400;
+        m_spCameraInfoManager->setCameraInfo(info);
+#endif //#ifdef TEST_SETCAMERAINFO
+
+#ifdef ENABLE_RTSP
+        if (m_spRTSPServer && m_spWinMFCaptureRtsp)
+        {
+            m_spWinMFCaptureRtsp->StartStreaming();
+            m_rtspHandlerToken = m_spWinMFCaptureRtsp->AddSampleHandler({ this, &MsftCameraNode::rtpHandler });
+            m_spRTSPServer->StartServer();
+        }
+#endif
+    }
+
+    void Stop()
+    {
+        std::mutex mutexFinish;
+        std::unique_lock<std::mutex> lockFinish(mutexFinish);
+        ThreadPool::RunAsync([&](IAsyncAction)
+            {
+                m_spWinMFCaptureRos? m_spWinMFCaptureRos->StopStreaming() : 0;
+                m_spWinMFCaptureRtsp ? m_spWinMFCaptureRtsp->StopStreaming() : 0;
+            });
+
+        if (m_imagePubHandlerToken)
+        {
+            m_eventFinish.wait(lockFinish);
+            m_spWinMFCaptureRos->RemoveSampleHandler(m_imagePubHandlerToken);
+            m_imagePubHandlerToken.value = 0;
+        }
+#ifdef ENABLE_RTSP
+        if (m_spRTSPServer)
+        {
+            m_spRTSPServer->StopServer();
+            if (m_rtspHandlerToken)
+            {
+                m_spWinMFCaptureRtsp->RemoveSampleHandler(m_rtspHandlerToken);
+                m_rtspHandlerToken.value = 0;
+            }
+        }
+#endif
+    }
+
+private:
+    std::string FormatUrl(std::string m_cameraInfoUrl)
+    {
+        auto pos = m_cameraInfoUrl.find("file:");
+        if (pos != std::string::npos)
+        {
+            // this block of code is required because there is a bug in camerainfo manager url based api 
+            // when handling file:// prefix url with local paths like "e:\folder"
+            // We convert such paths to unc path.
+
+            pos += 5; // length of "file:"
+            int slashCnt = 0;
+            while (m_cameraInfoUrl[++pos] == '/') slashCnt++;
+            if (m_cameraInfoUrl[pos] == '\\' && m_cameraInfoUrl[pos + 1] == '\\')
+            {
+                // unc path that needs conversion
+                auto path = m_cameraInfoUrl.substr(pos + 2);
+                m_cameraInfoUrl = std::string("file:////") + path;
+            }
+            else if (m_cameraInfoUrl[pos + 1] == ':')
+            {
+                //full drive path
+                auto path = m_cameraInfoUrl.substr(pos);
+                path[1] = '$'; // replace ':' with '$' to convert to unc path
+                m_cameraInfoUrl = std::string("file:////127.0.0.1\\") + path;
+            }
+            else if (slashCnt < 4) // if slashCnt >= 4 it is probably is an acceptable unc path
+            {
+                ROS_ERROR("camera info url for file must be a fully qualified drive path or unc path");
+            }
+        }
+        return m_cameraInfoUrl;
+    }
+
+    void ConfigureMFCapture(bool isController)
+    {
+        m_spWinMFCaptureRos = nullptr;
+        m_spWinMFCaptureRtsp = nullptr;
+#ifdef ENABLE_RTSP
+        m_spRTSPServer = nullptr;
+#endif
+        auto winMFcap = WindowsMFCapture::CreateInstance(m_isDevice, winrt::to_hstring(m_videoSourcePath), isController);
+        m_spWinMFCaptureRtsp.attach(winMFcap);
+        if (winMFcap->ChangeCaptureConfig(m_width, m_height, m_frameRate, g_rosPrefferdVideoFormat, !isController))
+        {
+#ifdef ENABLE_RTSP
+            rtspInVideoFormat = g_rosPrefferdVideoFormat;
+#endif
+            m_spWinMFCaptureRos.copy_from(winMFcap);
+        }
+        else
+        {
+#ifdef ENABLE_RTSP
+            if (hasParam("rtsp_port"))
+            {
+                winMFcap->ChangeCaptureConfig(m_width, m_height, m_frameRate, g_rtspPrefferdVideoFormat, true);
+                rtspInVideoFormat = g_rtspPrefferdVideoFormat;
+                m_spWinMFCaptureRos.attach(WindowsMFCapture::CreateInstance(m_isDevice, winrt::to_hstring(m_videoSourcePath), false));
             }
             else
+#endif
             {
-                if ((HRESULT)ex.code().value == MF_E_HW_MFT_FAILED_START_STREAMING)
-                {
-                    ROS_WARN("WindowsMFCapture streaming failed. Retrying with shared mode...\n");
-                    //  re-try with sharing mode
-                    camera->RemoveSampleHandler(imagePubHandlerToken);
-                    camera = nullptr;
-                    camera.attach(WindowsMFCapture::CreateInstance(isDevice, winrt::to_hstring(videoSourcePath), false));
-
-                    camera->ChangeCaptureConfig(Width, Height, frameRate, videoFormat, true);
-                    camera->StartStreaming();
-                    imagePubHandlerToken = camera->AddSampleHandler(rosImagePubHandler);
-
-                    ROS_WARN("WindowsMFCapture is in shared mode. Config paramters may not be applied \n");
-                }
-                if ((HRESULT)ex.code().value == MF_E_END_OF_STREAM)
-                {
-                    ROS_INFO("\nEOS");
-                }
-                eventFinish.notify_all();
+                m_spWinMFCaptureRos.attach(winMFcap);
             }
-        };
+            m_spWinMFCaptureRos->ChangeCaptureConfig(m_width, m_height, m_frameRate, g_rosPrefferdVideoFormat, true);
+        }
 
-        camera.attach(WindowsMFCapture::CreateInstance(isDevice, winrt::to_hstring(videoSourcePath), true));
-        camera->ChangeCaptureConfig(Width, Height, frameRate, videoFormat, true);
-        if (privateNode.hasParam("rtsp_port"))
+#ifdef ENABLE_RTSP
+        /*RTSP*/
+        if (hasParam("rtsp_port"))
         {
-            spSinkWriter.attach(SetupRTSPServer(Width, Height, frameRate, videoFormat, &privateNode, spRTSPServer.put()));
+            SetupRTSPServer(m_width, m_height, m_frameRate, rtspInVideoFormat, this);
             winrt::LogHandler rtsplogger([](winrt::hresult hr, winrt::hstring msg)
                 {
                     if (SUCCEEDED(hr.value))
@@ -312,39 +234,268 @@ int main(int argc, char** argv)
             for (int l = (int)LoggerType::ERRORS; l < (int)LoggerType::LOGGER_MAX; l++)
             {
                 EventRegistrationToken t;
-                spRTSPServer->AddLogHandler((LoggerType)l, rtsplogger.as<ABI::LogHandler>().get(), &t);
+                m_spRTSPServer->AddLogHandler((LoggerType)l, rtsplogger.as<ABI::LogHandler>().get(), &t);
             }
-            spRTSPServer->StartServer();
         }
-        camera->StartStreaming();
-        imagePubHandlerToken = camera->AddSampleHandler(rosImagePubHandler);
-        
+#endif
+    }
 
-#ifdef TEST_SETCAMERAINFO
-        Sleep(10000);
-        auto info = spCameraInfoManager->getCameraInfo();
-        info.height = 720;
-        info.width = 400;
-        spCameraInfoManager->setCameraInfo(info);
-#endif //#ifdef TEST_SETCAMERAINFO
-
-        ros::spin();
-
-        std::mutex mutexFinish;
-        std::unique_lock<std::mutex> lockFinish(mutexFinish);
-        ThreadPool::RunAsync([camera](IAsyncAction)
+    void ImagePubHandler(winrt::hresult_error ex, winrt::hstring msg, IMFSample* pSample)
+    {
+        if (pSample)
+        {
+            auto info = m_spCameraInfoManager->getCameraInfo();
+            if (((info.height != m_height) || (info.width != m_width)) && info.height && info.width && (!m_configChangeInProgress))
             {
-                camera->StopStreaming();
-            });
-        eventFinish.wait(lockFinish);
-        return 0;
+                m_configChangeInProgress = true;
+                ThreadPool::RunAsync([&](IAsyncAction)
+                    {
+                        auto info = m_spCameraInfoManager->getCameraInfo();
+                        if (m_spWinMFCaptureRos->ChangeCaptureConfig(info.width, info.height, m_frameRate, g_rosPrefferdVideoFormat, true))
+                        {
+                            m_height = info.height;
+                            m_width = info.width;
+                            m_configChangeInProgress = false;
+                        }
+                        else
+                        {
+                            ROS_WARN("Setting resolution  failed. Use rescale_camera_info param for rescaling");
+                        }
+                    });
+            }
+            else
+            {
+                m_spRawImagePublisher->OnSample(pSample, (UINT32)m_width, (UINT32)m_height);
+            }
+        }
+        else
+        {
+            HandleStreamingErrors(ex.code());
+        }
     }
-    catch (hresult_error const& ex)
+
+    void HandleStreamingErrors(HRESULT hr)
     {
-        ROS_ERROR(winrt::to_string(ex.message() + L":" + winrt::to_hstring(ex.code())).c_str());
+        if ((hr == MF_E_HW_MFT_FAILED_START_STREAMING)
+            || (hr == winrt::impl::hresult_from_win32(ERROR_SHARING_VIOLATION))
+            )
+        {
+            if (!m_configChangeInProgress)
+            {
+                //  re-try with sharing mode
+                ROS_WARN("WindowsMFCapture streaming failed. Retrying with shared mode...\n");
+                m_configChangeInProgress = true;
+                ThreadPool::RunAsync([this](IAsyncAction)
+                    {
+                        Stop();
+                        ConfigureMFCapture(false);
+                        Start();
+                        m_configChangeInProgress = false;
+                        ROS_WARN("WindowsMFCapture is in shared mode. Config paramters may not be applied \n");
+                    });
+            }
+            else
+            {
+                ROS_WARN("Config Change is in progress.. \n");
+                return;
+            }
+        }
+        if (hr == MF_E_END_OF_STREAM)
+        {
+            ROS_INFO("\nEOS");
+        }
+        m_eventFinish.notify_all();
     }
-    catch (...)
+
+    std::string m_videoSourcePath = "";
+    std::string m_frameId = "camera";
+    std::string m_cameraInfoUrl = "";
+    bool m_isDevice = true;
+    float m_frameRate = DEFAULT_FRAMERATE;
+    int32_t m_queueSize = PUBLISHER_QUEUE_SIZE;
+    int32_t m_width = DEFAULT_WIDTH;
+    int32_t m_height = DEFAULT_HEIGHT;
+    winrt::com_ptr<ros_msft_camera::WindowsMFCapture> m_spWinMFCaptureRos, m_spWinMFCaptureRtsp;
+    std::shared_ptr<camera_info_manager::CameraInfoManager> m_spCameraInfoManager;
+    bool m_configChangeInProgress = false;
+    std::unique_ptr<WinRosPublisherImageRaw> m_spRawImagePublisher;
+    std::condition_variable m_eventFinish;
+    winrt::event_token m_imagePubHandlerToken, m_rtspHandlerToken;
+
+    /*RTSP*/
+#ifdef ENABLE_RTSP
+    void InitSinkWriter(IMFMediaSink* pMediaSink, uint32_t width, uint32_t height, float framerate, GUID subType)
     {
-        ROS_ERROR(winrt::to_string(L"\nError:" + winrt::to_hstring(winrt::to_hresult())).c_str());
+        com_ptr<IMFAttributes> spSWAttributes;
+        winrt::com_ptr<IMFMediaType> spInType;
+
+        check_hresult(MFCreateMediaType(spInType.put()));
+        check_hresult(MFSetAttributeSize(spInType.get(), MF_MT_FRAME_SIZE, width, height));
+        check_hresult(MFSetAttributeRatio(spInType.get(), MF_MT_FRAME_RATE, (uint32_t)(framerate * 100), 100));
+
+        check_hresult(spInType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video));
+        check_hresult(spInType->SetGUID(MF_MT_SUBTYPE, subType));
+
+        check_hresult(MFCreateAttributes(spSWAttributes.put(), 2));
+        check_hresult(spSWAttributes->SetUINT32(MF_LOW_LATENCY, TRUE));
+        HRESULT hr = S_OK;
+        BOOL bEnableHWTransforms = FALSE;
+        do
+        {
+            m_spSinkWriter = nullptr;
+            check_hresult(spSWAttributes->SetUINT32(MF_READWRITE_ENABLE_HARDWARE_TRANSFORMS, bEnableHWTransforms));
+            check_hresult(MFCreateSinkWriterFromMediaSink(pMediaSink, spSWAttributes.get(), m_spSinkWriter.put()));
+            hr = m_spSinkWriter->SetInputMediaType(0, spInType.get(), nullptr);
+            bEnableHWTransforms = !bEnableHWTransforms;
+        } while (hr == MF_E_TOPO_CODEC_NOT_FOUND);
+        check_hresult(hr);
+        check_hresult(m_spSinkWriter->BeginWriting());
     }
+
+    IRTSPAuthProvider* SetupRTSPAuthentication(ros::NodeHandle* pPrivateNode)
+    {
+        winrt::com_ptr<IRTSPAuthProvider> spAuthProvider;
+        std::map<std::string, std::string> credsAdd;
+        std::vector<std::string> credsRemove;
+        pPrivateNode->param("rtsp_AddCredentials", credsAdd, credsAdd);
+        pPrivateNode->param("rtsp_RemoveCredentials", credsRemove, credsRemove);
+        winrt::check_hresult(GetAuthProviderInstance(AuthType::Digest, winrt::to_hstring(pPrivateNode->getNamespace()).c_str(), spAuthProvider.put()));
+        auto spCredStore = spAuthProvider.as<IRTSPAuthProviderCredStore>();
+        for (auto&& user : credsRemove)
+        {
+            winrt::check_hresult(spCredStore->RemoveUser(winrt::to_hstring(user).c_str()));
+        }
+        for (auto&& cred : credsAdd)
+        {
+            auto user = winrt::to_hstring(cred.first);
+            auto pass = winrt::to_hstring(cred.second);
+            winrt::check_hresult(spCredStore->AddUser(user.c_str(), pass.c_str()));
+        }
+
+        return spAuthProvider.detach();
+    }
+
+    // sample test code to get localhost test certificate
+    std::vector<PCCERT_CONTEXT> GetServerCertificate(LPCWSTR subject)
+    {
+        std::vector<PCCERT_CONTEXT> aCertContext;
+        PCCERT_CONTEXT pCertContext = NULL;
+        //-------------------------------------------------------
+        // Open the My store, also called the personal store.
+        // This call to CertOpenStore opens the Local_Machine My 
+        // store as opposed to the Current_User's My store.
+
+        auto hMyCertStore = CertOpenStore(CERT_STORE_PROV_SYSTEM,
+            X509_ASN_ENCODING,
+            0,
+            CERT_SYSTEM_STORE_LOCAL_MACHINE,
+            L"MY");
+
+        if (hMyCertStore == NULL)
+        {
+            ROS_ERROR("Error opening MY store for server.\n");
+            return aCertContext;
+        }
+        //-------------------------------------------------------
+        // Search for a certificate with some specified
+        // string in it. This example attempts to find
+        // a certificate with the string "example server" in
+        // its subject string. Substitute an appropriate string
+        // to find a certificate for a specific user.
+        do
+        {
+            pCertContext = CertFindCertificateInStore(hMyCertStore,
+                X509_ASN_ENCODING,
+                0,
+                CERT_FIND_SUBJECT_STR_W,
+                subject, // use appropriate subject name
+                pCertContext
+            );
+            if (pCertContext)
+            {
+                aCertContext.push_back(CertDuplicateCertificateContext(pCertContext));
+            }
+        } while (pCertContext);
+
+        if (aCertContext.empty())
+        {
+            ROS_ERROR("Error retrieving server certificate.");
+        }
+
+        if (hMyCertStore)
+        {
+            CertCloseStore(hMyCertStore, 0);
+        }
+        return aCertContext;
+    }
+
+    void SetupRTSPServer(uint32_t width, uint32_t height, float framerate, GUID inSubType, ros::NodeHandle* pPrivateNode)
+    {
+        winrt::com_ptr<IMFMediaType> spOutMT;
+        winrt::com_ptr<IMFMediaSink> spMediaSink;
+        std::vector<PCCERT_CONTEXT> pCert;
+        int rtspPort = DEFAULT_RTSP_PORT;
+        std::string secureCertSubject = "";
+        int bitRate = width * 1000;
+
+        pPrivateNode->param("rtsp_port", rtspPort, rtspPort);
+        pPrivateNode->param("rtsps_cert_subject", secureCertSubject, secureCertSubject);
+        pPrivateNode->param("rtp_bitrate", bitRate, bitRate);
+
+        MFCreateMediaType(spOutMT.put());
+        check_hresult(MFSetAttributeSize(spOutMT.get(), MF_MT_FRAME_SIZE, width, height));
+        check_hresult(MFSetAttributeRatio(spOutMT.get(), MF_MT_FRAME_RATE, (uint32_t)(framerate * 100), 100));
+        winrt::check_hresult(spOutMT->SetUINT32(MF_MT_AVG_BITRATE, bitRate));
+
+        winrt::check_hresult(spOutMT->SetUINT32(MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive));
+        check_hresult(spOutMT->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video));
+        check_hresult(spOutMT->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_H264));
+
+        IMFMediaType* mts[1];
+        mts[0] = spOutMT.get();
+        winrt::check_hresult(CreateRTPMediaSink(mts, 1, spMediaSink.put()));
+        InitSinkWriter(spMediaSink.get(), width, height, framerate, inSubType);
+        winrt::RTSPSuffixSinkMap rtspMap;
+        rtspMap.Insert(L"/", spMediaSink.as<winrt::Windows::Foundation::IInspectable>());
+        if (!secureCertSubject.empty())
+        {
+            pCert = GetServerCertificate(winrt::to_hstring(secureCertSubject).c_str());
+        }
+        winrt::com_ptr<IRTSPAuthProvider> spAuthProvider;
+        spAuthProvider.attach(SetupRTSPAuthentication(pPrivateNode));
+        winrt::check_hresult(CreateRTSPServer(rtspMap.as<ABI::RTSPSuffixSinkMap>().get(), rtspPort, !pCert.empty(), spAuthProvider.get(), pCert.data(), pCert.size(), m_spRTSPServer.put()));
+
+    }
+
+    void rtpHandler(winrt::hresult_error ex, winrt::hstring msg, IMFSample* pSample)
+    {
+        if (pSample)
+        {
+            winrt::check_hresult(m_spSinkWriter->WriteSample(0, pSample));
+        }
+        else
+        {
+            // if both capture objects are same, then the ImagePubHandler 
+            // (set on m_spWinMFCaptureRos) must have received the same error; Let ImagePubHandler handle this error.
+            if (m_spWinMFCaptureRos != m_spWinMFCaptureRtsp)
+            {
+                HandleStreamingErrors(ex.code());
+            }
+        }
+    }
+
+
+    GUID rtspInVideoFormat = MFVideoFormat_NV12;
+    winrt::com_ptr<IMFSinkWriter> m_spSinkWriter;
+    winrt::com_ptr<IRTSPServerControl> m_spRTSPServer;
+#endif //ENABLE_RTSP
+};
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "msft_camera");
+    MsftCameraNode cameraNode("~");
+    cameraNode.Start();
+    ros::spin();
+    cameraNode.Stop();
 }

--- a/src/msftcameranode.cpp
+++ b/src/msftcameranode.cpp
@@ -25,7 +25,6 @@ constexpr int32_t DEFAULT_RTSP_PORT = 8554;
 const GUID g_rosPrefferdVideoFormat = MFVideoFormat_ARGB32;
 const GUID g_rtspPrefferdVideoFormat = MFVideoFormat_NV12;
 
-//#define ENABLE_RTSP
 class MsftCameraNode : ros::NodeHandle
 {
 public:

--- a/src/msftcameranode.cpp
+++ b/src/msftcameranode.cpp
@@ -232,7 +232,7 @@ private:
                 });
             for (int l = (int)LoggerType::ERRORS; l < (int)LoggerType::LOGGER_MAX; l++)
             {
-                EventRegistrationToken t;
+                ::EventRegistrationToken t;
                 m_spRTSPServer->AddLogHandler((LoggerType)l, rtsplogger.as<ABI::LogHandler>().get(), &t);
             }
         }

--- a/src/msftcameranodelet.cpp
+++ b/src/msftcameranodelet.cpp
@@ -34,7 +34,7 @@ namespace ros_msft_camera
             auto privateNode = getPrivateNodeHandle();
             std::string videoSourcePath = "";
             bool isDevice = true;
-            std::string frame_id("camera");
+            std::string frameId("camera");
             std::string cameraInfoUrl("");
             privateNode.param("frame_rate", m_frameRate, 30.0f);
             privateNode.param("pub_queue_size", m_QueueSize, PUBLISHER_QUEUE_SIZE);
@@ -42,7 +42,7 @@ namespace ros_msft_camera
             privateNode.param("image_width", m_Width, 640);
             privateNode.param("image_height", m_Height, 480);
 
-            privateNode.param("frame_id", frame_id, std::string("camera"));
+            privateNode.param("frame_id", frameId, std::string("camera"));
             privateNode.getParam("videoDeviceId", videoSourcePath);
             if (videoSourcePath.empty())
             {
@@ -58,8 +58,8 @@ namespace ros_msft_camera
                 }
             }
 
-            m_spRawPublisher = std::make_shared<WinRosPublisherImageRaw>(privateNode, "image_raw", m_QueueSize, frame_id, m_spCameraInfoManager.get());
-            m_spMFSamplePublisher = std::make_shared<WinRosPublisherMFSample>(privateNode, "MFSample", m_QueueSize, frame_id, m_spCameraInfoManager.get());
+            m_spRawPublisher = std::make_shared<WinRosPublisherImageRaw>(privateNode, "image_raw", m_QueueSize, frameId, m_spCameraInfoManager);
+            m_spMFSamplePublisher = std::make_shared<WinRosPublisherMFSample>(privateNode, "MFSample", m_QueueSize, frameId, m_spCameraInfoManager);
 
             m_spCameraInfoManager = std::make_shared<camera_info_manager::CameraInfoManager>(privateNode, "frame_id");
             if (privateNode.getParam("camera_info_url", cameraInfoUrl))
@@ -110,22 +110,6 @@ namespace ros_msft_camera
                 }
             };
 
-            auto compressedSampleHandler = [&](winrt::hresult_error ex, winrt::hstring msg, IMFSample* pSample)
-            {
-                if (pSample)
-                {
-                    ROS_INFO("Received compressed Sample\n");
-                }
-                else
-                {
-                    if ((HRESULT)ex.code().value == MF_E_END_OF_STREAM)
-                    {
-                        ROS_INFO("\nEOS");
-                    }
-
-                    m_conditionFinish.notify_all();
-                }
-            };
             std::mutex mutexFinish;
 
             std::unique_lock<std::mutex> ul(mutexFinish);

--- a/test/camnodeRTSP.launch
+++ b/test/camnodeRTSP.launch
@@ -1,0 +1,9 @@
+<launch>
+  <node pkg="msft_camera" type="msft_camera_node" name="msft_camera_node">
+    <param name="frame_id" value="MsftCameraRTSP" />
+    <param name="image_width" value="1280" />
+    <param name="image_height" value="720" />
+    <param name="frame_rate" value="30.0" />
+    <rosparam command="load" file="$(find msft_camera)/test/rtsp.yaml" />
+  </node>
+</launch>

--- a/test/rtsp.yaml
+++ b/test/rtsp.yaml
@@ -1,0 +1,2 @@
+rtsp_port: 8554
+rtsp_AddCredentials: {user: pass}

--- a/test/rtsp_secure.yaml
+++ b/test/rtsp_secure.yaml
@@ -1,0 +1,3 @@
+rtsp_port: 8554
+rtsp_AddCredentials: {user: pass}
+rtsps_cert_subject: "localhost"


### PR DESCRIPTION
This source contains a feature to stream out the captured video over RTSP/RTP using H.264 video compression for remote teleoperation and telepresence applications.
The streaming feature supports the following:  
- H.264 over RTP (session negotiation via RTSP)
- RTSP digest and basic authentication 
- RTSP over secure(TLS) connection (RTSPS)  
The RTSP/RTP streaming related libraries are a part of a sub-module from the [Windows-Camera repository](https://github.com/microsoft/Windows-Camera/tree/release/NetworkVideoStreamer_1_0)
For more details on streaming [visit this page](https://github.com/microsoft/Windows-Camera/blob/release/NetworkVideoStreamer_1_0/README.md)  

Other changes include camera node code reformatting, cleanup and bug fixes related to camera sharing.