### PR TITLE
Some fixes for usability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.15.3)
-project(msft_camera)
+project(ros_msft_camera)
 
 find_package(catkin REQUIRED COMPONENTS
-  image_transport roscpp sensor_msgs nodelet camera_info_manager roslint std_msgs message_generation roslint)
+  image_transport roscpp sensor_msgs nodelet camera_info_manager roslint std_msgs roslint)
 
 find_package(Boost REQUIRED COMPONENTS system thread)
 
@@ -10,22 +10,15 @@ set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set (CMAKE_CXX_EXTENSIONS FALSE)
 
+add_definitions(/D_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS /DBOOST_BIND_GLOBAL_PLACEHOLDERS)
 add_compile_options(/EHsc)
 
 roslint_cpp()
-add_message_files(
-   FILES
-   MFSample.msg
- )
-generate_messages(
-   DEPENDENCIES
-   std_msgs
- )
-  
+
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES win_camera
-  CATKIN_DEPENDS image_transport roscpp sensor_msgs nodelet camera_info_manager message_runtime
+  LIBRARIES ${PROJECT_NAME}_lib
+  CATKIN_DEPENDS image_transport roscpp sensor_msgs nodelet camera_info_manager
   )
 
 include_directories(
@@ -41,24 +34,22 @@ include(external/CmakeLists.txt)
 endif(ENABLE_RTSP)
 
 ## Declare a cpp library
-add_library(win_camera STATIC src/winrospublisher.cpp src/wincapture.cpp)
+add_library(${PROJECT_NAME}_lib STATIC src/winrospublisher.cpp src/wincapture.cpp)
 
-add_dependencies(win_camera msft_camera_generate_messages_cpp)
-
-add_library(msft_camera_nodelet SHARED src/msftcameranodelet.cpp)
-set_target_properties(msft_camera_nodelet PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE) 
+add_library(${PROJECT_NAME}_nodelet SHARED src/msftcameranodelet.cpp)
+set_target_properties(${PROJECT_NAME}_nodelet PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE) 
 
 ## Declare a cpp executable
-add_executable(msft_camera_node src/msftcameranode.cpp)
-add_dependencies(msft_camera_node win_camera)
+add_executable(${PROJECT_NAME}_node src/msftcameranode.cpp)
+add_dependencies(${PROJECT_NAME}_node ${PROJECT_NAME}_lib)
 if(ENABLE_RTSP)
-add_dependencies(msft_camera_node RTPMediaStreamer RTSPServer)
+add_dependencies(${PROJECT_NAME}_node RTPMediaStreamer RTSPServer)
 endif(ENABLE_RTSP)
 
-add_dependencies(msft_camera_nodelet win_camera)
+add_dependencies(${PROJECT_NAME}_nodelet ${PROJECT_NAME}_lib)
 
 ## Specify libraries to link a library or executable target against
-target_link_libraries(win_camera
+target_link_libraries(${PROJECT_NAME}_lib
   ${catkin_LIBRARIES}
   )
 
@@ -69,7 +60,7 @@ set(RTSP_LIBS
 endif(ENABLE_RTSP)
 
 set (COMMON_LIBS 
-     win_camera
+     ${PROJECT_NAME}_lib
      mf
      mfplat
      mfuuid
@@ -78,13 +69,13 @@ set (COMMON_LIBS
      shlwapi
      runtimeobject)
 
-target_link_libraries(msft_camera_nodelet
+target_link_libraries(${PROJECT_NAME}_nodelet
   ${catkin_LIBRARIES}
   ${COMMON_LIBS}
   )
 
 
-target_link_libraries(msft_camera_node
+target_link_libraries(${PROJECT_NAME}_node
   ${catkin_LIBRARIES}
   ${COMMON_LIBS}
   ${RTSP_LIBS}
@@ -93,16 +84,7 @@ target_link_libraries(msft_camera_node
 #############
 ## Install ##
 #############
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables and/or libraries for installation
-install(TARGETS win_camera msft_camera_nodelet msft_camera_node
+install(TARGETS ${PROJECT_NAME}_lib ${PROJECT_NAME}_nodelet ${PROJECT_NAME}_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -110,6 +92,14 @@ install(TARGETS win_camera msft_camera_nodelet msft_camera_node
 
 install(DIRECTORY include
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  )
+
+install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  )
+
+install(DIRECTORY config
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   )
 
 # add xml file
@@ -130,9 +120,9 @@ if (CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   add_rostest_gtest(testMsftCamera test/msftCamera.test
     test/testMsftCamera.cpp)
-  target_link_libraries(testMsftCamera win_camera ${catkin_LIBRARIES})
+  target_link_libraries(testMsftCamera ${PROJECT_NAME}_lib ${catkin_LIBRARIES})
 
   add_rostest_gtest(testMsftCameraNoYaml test/msftCameraNoYaml.test
     test/testMsftCameraNoYaml.cpp)
-  target_link_libraries(testMsftCameraNoYaml win_camera ${catkin_LIBRARIES})
+  target_link_libraries(testMsftCameraNoYaml ${PROJECT_NAME}_lib ${catkin_LIBRARIES})
 endif()

--- a/config/default_calibration.yaml
+++ b/config/default_calibration.yaml
@@ -1,0 +1,20 @@
+image_width: 1280
+image_height: 720
+camera_name: camera
+camera_matrix:
+  rows: 3
+  cols: 3
+  data: [4827.94, 0, 1223.5, 0, 4835.62, 1024.5, 0, 0, 1]
+distortion_model: plumb_bob
+distortion_coefficients:
+  rows: 1
+  cols: 5
+  data: [-0.41527, 0.31874, -0.00197, 0.00071, 0]
+rectification_matrix:
+  rows: 3
+  cols: 3
+  data: [1, 0, 0, 0, 1, 0, 0, 0, 1]
+projection_matrix:
+  rows: 3
+  cols: 4
+  data: [4827.94, 0, 1223.5, 0, 0, 4835.62, 1024.5, 0, 0, 0, 1, 0]

--- a/config/rtsp.yaml
+++ b/config/rtsp.yaml
@@ -1,0 +1,2 @@
+rtsp_port: 8554
+rtsp_AddCredentials: {user: pass}

--- a/include/winrospublisher.h
+++ b/include/winrospublisher.h
@@ -9,7 +9,7 @@
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/image_encodings.h>
 #include <camera_info_manager/camera_info_manager.h>
-#include <msft_camera\MFSample.h>
+#include <std_msgs/UInt64.h>
 #include <memory>
 #include <queue>
 using namespace winrt;
@@ -108,7 +108,7 @@ namespace ros_msft_camera
                         ros_image->step = -Stride;
                         size_t size = ros_image->step * u32Height;
                         ros_image->data.resize(size);
-                        for (int i = 0; i < u32Height; i++)
+                        for (uint32_t i = 0; i < u32Height; i++)
                         {
                             memcpy(ros_image->data.data(), pix + Stride * i, -Stride);
                         }
@@ -163,17 +163,16 @@ namespace ros_msft_camera
             : WinRosPublisherBase(node, topic_name, queue_size, frame_id, pCameraInfoManager)
             , m_queueSize(queue_size)
         {
-            m_MFSamplePublisher = m_nodeHandle.advertise<msft_camera::MFSample>(topic_name, queue_size);
+            m_MFSamplePublisher = m_nodeHandle.advertise<std_msgs::UInt64>(topic_name, queue_size);
         }
         virtual ~WinRosPublisherMFSample() = default;
         void OnSample(IMFSample* pSample, UINT32 u32Width, UINT32 u32Height)
         {
             m_sampleQueue.emplace(nullptr);
             m_sampleQueue.back().copy_from(pSample);
-            msft_camera::MFSamplePtr sampleMsg = boost::make_shared<msft_camera::MFSample>();
-            sampleMsg->header = m_cameraInfo.header;
-            sampleMsg->pSample = (UINT64)pSample;
-            m_MFSamplePublisher.publish(*sampleMsg);
+            std_msgs::UInt64 sampleMsg;
+            sampleMsg.data = (UINT64)pSample;
+            m_MFSamplePublisher.publish(sampleMsg);
             if (m_sampleQueue.size() > m_queueSize)
             {
                 m_sampleQueue.pop();

--- a/launch/ros_msft_camera.launch
+++ b/launch/ros_msft_camera.launch
@@ -1,0 +1,9 @@
+<launch>
+  <node pkg="ros_msft_camera" type="ros_msft_camera_node" name="camera">
+    <param name="camera_info_url" value="file://$(find ros_msft_camera)/config/default_calibration.yaml" />
+    <param name="frame_id" value="camera" />
+    <param name="image_width" value="1280" />
+    <param name="image_height" value="720" />
+    <param name="frame_rate" value="30.0" />
+  </node>
+</launch>

--- a/launch/ros_msft_camera_rtsp.launch
+++ b/launch/ros_msft_camera_rtsp.launch
@@ -1,8 +1,9 @@
 <launch>
   <node pkg="ros_msft_camera" type="ros_msft_camera_node" name="ros_msft_camera_node">
-    <param name="frame_id" value="MsftCamera1" />
+    <param name="frame_id" value="MsftCameraRTSP" />
     <param name="image_width" value="1280" />
     <param name="image_height" value="720" />
     <param name="frame_rate" value="30.0" />
+    <rosparam command="load" file="$(find msft_camera)/config/rtsp.yaml" />
   </node>
 </launch>

--- a/msft_camera_nodelets.xml
+++ b/msft_camera_nodelets.xml
@@ -1,6 +1,6 @@
-<library path="lib/libmsft_camera_nodelet">
+<library path="lib/ros_msft_camera_nodelet">
 
-  <class name="ros_win_camera/MsftCameraNodelet"
+  <class name="ros_msft_camera/MsftCameraNodelet"
 	 type="ros_win_camera::MsftCameraNodelet" base_class_type="nodelet::Nodelet">
     <description>
       Microsoft Media Foundation based camera driver nodelet.

--- a/msg/MFSample.msg
+++ b/msg/MFSample.msg
@@ -1,2 +1,0 @@
-Header header
-int64 pSample

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package>
-  <name>msft_camera</name>
+  <name>ros_msft_camera</name>
   <version>0.1.1</version>
   <description>msft_camera uses Windows Media Foundation to capture camera image.
   </description>
@@ -8,9 +8,9 @@
   <license>MIT</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>message_generation</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend>std_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>nodelet</build_depend>
   <build_depend>camera_info_manager</build_depend>
@@ -18,10 +18,10 @@
   <build_depend>roslint</build_depend>
   
   
-  <run_depend>message_runtime</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>std_msgs</run_depend>
   <run_depend>nodelet</run_depend>
   <run_depend>camera_info_manager</run_depend>
 

--- a/src/msftcameranode.cpp
+++ b/src/msftcameranode.cpp
@@ -492,7 +492,7 @@ private:
 
 int main(int argc, char** argv)
 {
-    ros::init(argc, argv, "msft_camera");
+    ros::init(argc, argv, "ros_msft_camera");
     MsftCameraNode cameraNode("~");
     cameraNode.Start();
     ros::spin();

--- a/src/wincapture.cpp
+++ b/src/wincapture.cpp
@@ -126,7 +126,6 @@ namespace ros_msft_camera
         if (m_bStreamingStarted) return;
 
         winrt::com_ptr <IMFMediaType> spMT;
-        GUID subtype;
 
         check_hresult(spSourceReader->SetStreamSelection((DWORD)MF_SOURCE_READER_FIRST_VIDEO_STREAM, TRUE));
         check_hresult(spSourceReader->ReadSample(MF_SOURCE_READER_FIRST_VIDEO_STREAM, m_u32SourceReaderFlags, NULL, NULL, NULL, NULL));
@@ -136,7 +135,6 @@ namespace ros_msft_camera
     void WindowsMFCapture::InitCaptureWithUrl(const winrt::hstring& url)
     {
         winrt::com_ptr<IMFAttributes> spSRAttributes;
-        GUID subtype;
 
         check_hresult(CoInitialize(NULL));
         check_hresult(MFStartup(MF_VERSION));
@@ -297,7 +295,6 @@ namespace ros_msft_camera
         {
             HRESULT hr = S_OK;
             winrt::com_ptr<IMFMediaType> spMediaType;
-            UINT32 FRNum, FRDen;
             int idx = 0;
             _INFO("\nSetting resolution :%dx%d@%f", width, height, frameRate);
             if (!m_bIsController)
@@ -343,7 +340,6 @@ namespace ros_msft_camera
             else
             {
                 DWORD flags = 0;
-                GUID subtype;
                 HRESULT hr = spSourceReader.as<IMFSourceReaderEx>()->SetNativeMediaType(MF_SOURCE_READER_FIRST_VIDEO_STREAM, spMediaType.get(), &flags);
 
                 if (SUCCEEDED(hr))

--- a/test/msftCamera.test
+++ b/test/msftCamera.test
@@ -3,7 +3,7 @@
     <param name="frame_id" value="MsftCamera1" />
     <param name="image_width" value="1280" />
     <param name="image_height" value="720" />
-    <param name="camera_info_url" value="file://$(find msft_camera)\test\sample.yaml" />
+    <param name="camera_info_url" value="file://$(find ros_msft_camera)\test\sample.yaml" />
     <param name="frame_rate" value="30.0" />
   </node>
   <test test-name="testMsftCamera" pkg="msft_camera" type="testMsftCamera" />


### PR DESCRIPTION
This change does the following:

* Standardizes on ros_msft_camera throughout
* Adds default launch file and config
* Removes unused message (which should be a separate package if reintroduced)
* Removes unused local variables
* Uses `camera` as the default.